### PR TITLE
Validate post-merge workflow comment runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Terraform Bridge Provider Boilerplate
 
 This repository contains boilerplate code for building a new Pulumi provider which wraps an existing Terraform provider.
+It also includes repository automation for post-merge workflow link comments.
 
 ## Background
 


### PR DESCRIPTION
Docs-only change used to validate the merged-PR comment workflow end to end.